### PR TITLE
新增公共API服务器 支持VIP解析

### DIFF
--- a/docs/.vitepress/theme/components/NeteaseApiTable.vue
+++ b/docs/.vitepress/theme/components/NeteaseApiTable.vue
@@ -65,9 +65,9 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, type Ref } from 'vue'
 import { useRoute } from 'vitepress'
-import neteaseApiList from '../data/netease-api'
+import neteaseApiList, { type NeteaseApiData } from '../data/netease-api'
 import { getSiteLocale } from '../utils/i18n'
 
 const route = useRoute()
@@ -125,13 +125,21 @@ const getApiVersion = async (link: string, isEnhanced: boolean): Promise<string>
   }
 }
 
-onMounted(async () => {
-  standardVersions.value = await Promise.all(
-    standardApis.value.map((api) => getApiVersion(api.link, false))
-  )
-  enhancedVersions.value = await Promise.all(
-    enhancedApis.value.map((api) => getApiVersion(api.link, true))
-  )
+const loadApiVersions = (
+  apis: NeteaseApiData[],
+  versions: Ref<string[]>,
+  isEnhanced: boolean
+) => {
+  for (const [index, api] of apis.entries()) {
+    void getApiVersion(api.link, isEnhanced).then((version) => {
+      versions.value[index] = version
+    })
+  }
+}
+
+onMounted(() => {
+  loadApiVersions(standardApis.value, standardVersions, false)
+  loadApiVersions(enhancedApis.value, enhancedVersions, true)
 })
 </script>
 

--- a/docs/.vitepress/theme/components/NeteaseApiTable.vue
+++ b/docs/.vitepress/theme/components/NeteaseApiTable.vue
@@ -61,6 +61,45 @@
         </table>
       </div>
     </div>
+
+
+    <!-- 增强VIP版 -->
+    <div class="api-section">
+      <h3>{{ t.enhancedVip }}</h3>
+      <div class="custom-block info">
+        <p class="custom-block-title">关于</p>
+        <p>此API由Sophia在增强版基础上进行闭源二次开发。</p>
+        <p>已内置网易云SVIP解析账号 可直接解析网易VIP歌曲。</p>
+        <p>仅支持ZMusic使用 其他接口已做封堵。</p>
+        <p>禁止违规使用此账号 无法解析联系QQ254164579。</p>
+      </div>
+      <div class="data-table data-table-mobile data-table-api">
+        <table>
+          <thead>
+            <tr>
+              <th>{{ t.apiUrl }}</th>
+              <th>{{ t.location }}</th>
+              <th>{{ t.provider }}</th>
+              <th>{{ t.version }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(api, index) in enhancedVipApis" :key="api.link">
+              <td :data-label="t.apiUrl">{{ api.link }}</td>
+              <td :data-label="t.location">{{ getLocation(api.location) }}</td>
+              <td :data-label="t.provider">
+                <a :href="api.provider.link" target="_blank" rel="noreferrer">
+                  {{ api.provider.name }}
+                </a>
+              </td>
+              <td :data-label="t.version">
+                <img :src="enhancedVipVersions[index]" :alt="`${api.link} version`" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -79,7 +118,8 @@ const i18n = {
     provider: '提供者',
     version: '版本',
     standard: '标准版',
-    enhanced: '增强版'
+    enhanced: '增强版',
+    enhancedVip: '增强 VIP 版'
   },
   '/en/': {
     apiUrl: 'API URL',
@@ -87,7 +127,8 @@ const i18n = {
     provider: 'Provider',
     version: 'Version',
     standard: 'Standard',
-    enhanced: 'Enhanced'
+    enhanced: 'Enhanced',
+    enhancedVip: 'Enhanced VIP'
   },
   '/ja/': {
     apiUrl: 'API URL',
@@ -95,7 +136,8 @@ const i18n = {
     provider: '提供者',
     version: 'バージョン',
     standard: '標準版',
-    enhanced: '拡張版'
+    enhanced: '拡張版',
+    enhancedVip: '拡張 VIP 版'
   }
 } as const
 
@@ -109,9 +151,11 @@ const FETCHING_BADGE = 'https://img.shields.io/badge/status-Fetching-lightgray'
 
 const standardApis = computed(() => neteaseApiList.filter((api) => api.type === 'standard'))
 const enhancedApis = computed(() => neteaseApiList.filter((api) => api.type === 'enhanced'))
+const enhancedVipApis = computed(() => neteaseApiList.filter((api) => api.type === 'enhanced-vip'))
 
 const standardVersions = ref<string[]>(standardApis.value.map(() => FETCHING_BADGE))
 const enhancedVersions = ref<string[]>(enhancedApis.value.map(() => FETCHING_BADGE))
+const enhancedVipVersions = ref<string[]>(enhancedVipApis.value.map(() => FETCHING_BADGE))
 
 const getApiVersion = async (link: string, isEnhanced: boolean): Promise<string> => {
   try {
@@ -131,6 +175,9 @@ onMounted(async () => {
   )
   enhancedVersions.value = await Promise.all(
     enhancedApis.value.map((api) => getApiVersion(api.link, true))
+  )
+  enhancedVipVersions.value = await Promise.all(
+    enhancedVipApis.value.map((api) => getApiVersion(api.link, true))
   )
 })
 </script>

--- a/docs/.vitepress/theme/components/NeteaseApiTable.vue
+++ b/docs/.vitepress/theme/components/NeteaseApiTable.vue
@@ -61,46 +61,6 @@
         </table>
       </div>
     </div>
-
-
-    <!-- 增强VIP版 -->
-    <div class="api-section">
-      <h3>{{ t.enhancedVip }}</h3>
-      <div class="custom-block info">
-        <p class="custom-block-title">关于</p>
-        <p>此API由Sophia在增强版基础上进行闭源二次开发。</p>
-        <p>已内置网易云SVIP解析账号 可直接解析网易VIP歌曲。</p>
-        <p>仅支持ZMusic使用 其他接口已做封堵。</p>
-        <p>此API无法使用/zmusic login。</p>
-        <p>禁止违规使用此账号 无法解析联系QQ254164579。</p>
-      </div>
-      <div class="data-table data-table-mobile data-table-api">
-        <table>
-          <thead>
-            <tr>
-              <th>{{ t.apiUrl }}</th>
-              <th>{{ t.location }}</th>
-              <th>{{ t.provider }}</th>
-              <th>{{ t.version }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="(api, index) in enhancedVipApis" :key="api.link">
-              <td :data-label="t.apiUrl">{{ api.link }}</td>
-              <td :data-label="t.location">{{ getLocation(api.location) }}</td>
-              <td :data-label="t.provider">
-                <a :href="api.provider.link" target="_blank" rel="noreferrer">
-                  {{ api.provider.name }}
-                </a>
-              </td>
-              <td :data-label="t.version">
-                <img :src="enhancedVipVersions[index]" :alt="`${api.link} version`" />
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -119,8 +79,7 @@ const i18n = {
     provider: '提供者',
     version: '版本',
     standard: '标准版',
-    enhanced: '增强版',
-    enhancedVip: '增强 VIP 版'
+    enhanced: '增强版'
   },
   '/en/': {
     apiUrl: 'API URL',
@@ -128,8 +87,7 @@ const i18n = {
     provider: 'Provider',
     version: 'Version',
     standard: 'Standard',
-    enhanced: 'Enhanced',
-    enhancedVip: 'Enhanced VIP'
+    enhanced: 'Enhanced'
   },
   '/ja/': {
     apiUrl: 'API URL',
@@ -137,8 +95,7 @@ const i18n = {
     provider: '提供者',
     version: 'バージョン',
     standard: '標準版',
-    enhanced: '拡張版',
-    enhancedVip: '拡張 VIP 版'
+    enhanced: '拡張版'
   }
 } as const
 
@@ -152,11 +109,9 @@ const FETCHING_BADGE = 'https://img.shields.io/badge/status-Fetching-lightgray'
 
 const standardApis = computed(() => neteaseApiList.filter((api) => api.type === 'standard'))
 const enhancedApis = computed(() => neteaseApiList.filter((api) => api.type === 'enhanced'))
-const enhancedVipApis = computed(() => neteaseApiList.filter((api) => api.type === 'enhanced-vip'))
 
 const standardVersions = ref<string[]>(standardApis.value.map(() => FETCHING_BADGE))
 const enhancedVersions = ref<string[]>(enhancedApis.value.map(() => FETCHING_BADGE))
-const enhancedVipVersions = ref<string[]>(enhancedVipApis.value.map(() => FETCHING_BADGE))
 
 const getApiVersion = async (link: string, isEnhanced: boolean): Promise<string> => {
   try {
@@ -176,9 +131,6 @@ onMounted(async () => {
   )
   enhancedVersions.value = await Promise.all(
     enhancedApis.value.map((api) => getApiVersion(api.link, true))
-  )
-  enhancedVipVersions.value = await Promise.all(
-    enhancedVipApis.value.map((api) => getApiVersion(api.link, true))
   )
 })
 </script>

--- a/docs/.vitepress/theme/components/NeteaseApiTable.vue
+++ b/docs/.vitepress/theme/components/NeteaseApiTable.vue
@@ -71,6 +71,7 @@
         <p>此API由Sophia在增强版基础上进行闭源二次开发。</p>
         <p>已内置网易云SVIP解析账号 可直接解析网易VIP歌曲。</p>
         <p>仅支持ZMusic使用 其他接口已做封堵。</p>
+        <p>此API无法使用/zmusic login。</p>
         <p>禁止违规使用此账号 无法解析联系QQ254164579。</p>
       </div>
       <div class="data-table data-table-mobile data-table-api">

--- a/docs/.vitepress/theme/data/netease-api.ts
+++ b/docs/.vitepress/theme/data/netease-api.ts
@@ -1,4 +1,4 @@
-export type NeteaseApiType = 'standard' | 'enhanced'
+export type NeteaseApiType = 'standard' | 'enhanced' | 'enhanced-vip'
 
 export interface NeteaseApiData {
   link: string
@@ -76,6 +76,20 @@ const neteaseApiList: NeteaseApiData[] = [
     provider: {
       name: '真心',
       link: 'https://github.com/RealHeart'
+    }
+  },
+  // 增强VIP版 (NeteaseCloudMusicApi-Enhanced-VIP 二次开发 闭源)
+  {
+    link: 'https://ncm.landdy.cn',
+    type: 'enhanced-vip',
+    location: {
+      '/': '全球',
+      '/en/': 'Global',
+      '/ja/': '全球'
+    },
+    provider: {
+      name: 'Sophia',
+      link: 'https://github.com/7ooki'
     }
   }
 ]

--- a/docs/.vitepress/theme/data/netease-api.ts
+++ b/docs/.vitepress/theme/data/netease-api.ts
@@ -1,4 +1,4 @@
-export type NeteaseApiType = 'standard' | 'enhanced' | 'enhanced-vip'
+export type NeteaseApiType = 'standard' | 'enhanced'
 
 export interface NeteaseApiData {
   link: string
@@ -78,14 +78,13 @@ const neteaseApiList: NeteaseApiData[] = [
       link: 'https://github.com/RealHeart'
     }
   },
-  // 增强VIP版 (NeteaseCloudMusicApi-Enhanced-VIP 二次开发 闭源)
   {
     link: 'https://ncm.landdy.cn',
-    type: 'enhanced-vip',
+    type: 'enhanced',
     location: {
       '/': '全球',
       '/en/': 'Global',
-      '/ja/': '全球'
+      '/ja/': 'グローバル'
     },
     provider: {
       name: 'Sophia',


### PR DESCRIPTION
## Summary

新增公共API服务器 支持VIP解析

## Changes

docs\.vitepress\theme\components\NeteaseApiTable.vue
docs\.vitepress\theme\data\netease-api.ts

## Verification
<img width="734" height="451" alt="image" src="https://github.com/user-attachments/assets/39bb2f91-c399-4812-9e5b-8dd0917a25b8" />
<img width="734" height="451" alt="image" src="https://github.com/user-attachments/assets/b92008cb-1fb5-4af4-9ea7-9475c8c6449b" />
<img width="1912" height="956" alt="image" src="https://github.com/user-attachments/assets/ee06102e-846f-4686-9cda-d37798980dbc" />


- [x] I have tested the relevant behavior.
- [x] I have updated documentation when needed.
- [x] I have checked that this change is scoped to the described issue or goal.

## Related Issues

No
